### PR TITLE
refactor: migrate faker to @faker-js/faker

### DIFF
--- a/gen.js
+++ b/gen.js
@@ -1,8 +1,5 @@
-// import { faker } from "@faker-js/faker";
-require('faker')
-require('fs')
-//import { writeFileSync } from "fs";
-
+const { faker } = require('@faker-js/faker');
+const { writeFileSync } = require('fs');
 const zareki_products = [
   "Zareki Timetable",
   "Zareki Finance",
@@ -24,7 +21,7 @@ const generateSchools = (numSchools) => {
       id: faker.number.int({ min: 10000, max: 70000 }),
       name: faker.company.name(),
       type: faker.helpers.arrayElement(["Primary", "Secondary", "IGCSE"]),
-      products: generateProducts,
+      products: generateProducts(),
       county: faker.location.county(),
       registrationDate: faker.date.past().toISOString(),
       contact: {
@@ -67,13 +64,13 @@ const generateInvoices = (numInvoices, schools) => {
 
 const statuses = ["Valid", "Bounced"];
 
-const generateCollections = (numCollections, schools) => {
+const generateCollections = (numCollections, schools, invoices) => {
   const collections = [];
   for (let i = 0; i < numCollections; i++) {
     const school = faker.helpers.arrayElement(schools);
     collections.push({
       id: faker.number.int({ min: 10000, max: 70000 }),
-      invoiceNumber: faker.helpers.arrayElement(invoices.invoiceNumber),
+      invoiceNumber: faker.helpers.arrayElement(invoices).invoiceNumber,
       collectionNumber: faker.number.int({ min: 100, max: 10000 }),
       dateOfCollection: faker.date.past().toISOString(),
       status: faker.helpers.arrayElement(statuses),
@@ -90,7 +87,7 @@ const numCollections = 30;
 
 const schools = generateSchools(numSchools);
 const invoices = generateInvoices(numInvoices, schools);
-const collections = generateCollections(numCollections, schools);
+const collections = generateCollections(numCollections, schools, invoices);
 
 const data = {
   schools,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "faker": "^6.6.6",
         "json-server": "^0.17.4"
       },
       "devDependencies": {
@@ -619,11 +618,6 @@
           "url": "https://feross.org/support"
         }
       ]
-    },
-    "node_modules/faker": {
-      "version": "6.6.6",
-      "resolved": "https://registry.npmjs.org/faker/-/faker-6.6.6.tgz",
-      "integrity": "sha512-9tCqYEDHI5RYFQigXFwF1hnCwcWCOJl/hmll0lr5D2Ljjb0o4wphb69wikeJDz5qCEzXCoPvG6ss5SDP6IfOdg=="
     },
     "node_modules/fill-range": {
       "version": "7.1.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "nodemon": "^3.1.1"
   },
   "dependencies": {
-    "faker": "^6.6.6",
     "json-server": "^0.17.4"
   }
 }


### PR DESCRIPTION
## Description

This PR replaces the old `faker` library with the new community-driven `@faker-js/faker` library. The original `faker` library, once a popular choice for generating fake data, became unmaintained in January 2022. In response, the community came together to create `@faker-js/faker`, ensuring continued support and improvements. You can read more about this on our [website](https://fakerjs.dev/about/announcements/2022-01-14.html#i-heard-something-happened-what-s-the-tldr).

For transparency, I want to mention that I'm one of the maintainers of the new library.

We are actively seeking projects that still use the old library. By migrating these projects, we aim to prevent developers from inadvertently using outdated libraries when searching for code examples.

## Additional Infomation

You already had `@faker-js/faker` installed and seemed to be using our API. I've gone ahead and removed the old `faker` library form your dependencies and correctly imported the new library so that the script works again.